### PR TITLE
CodeCommit support and misc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Security groups act as firewalls at the instance level, to control inbound and o
 
 </details>
 
+<details>
+	<summary>Diagram</summary>
+
+![VPC](images/vpc.png "VPC")
+
+</details>
 
 ### Bastion Host
 
@@ -103,6 +109,13 @@ See [Enabling Multi-factor authentication on the Bastion Host](docs/bastion-mfa.
 
 </details>
 
+<details>
+	<summary>Diagram</summary>
+
+![VPC + Bastion Host](images/vpc_bastion.png "VPC + Bastion Host")
+
+</details>
+
 ### AWS Elastic Beanstalk
 
 AWS Elastic Beanstalk is a service that lets you define an environment for common application types, and deploy code into it. The Beanstalk template is dependent on the VPC, and optionally can be used with the bastion, RDS, or Aurora templates.
@@ -127,6 +140,14 @@ The **_elastic-beanstalk.cfn.yml_** template asks for a series of inputs definin
 
 </details>
 
+<details>
+	<summary>Diagram</summary>
+
+![VPC + Bastion + Elastic Beanstalk + DB](images/vpc_bastion_eb_db.png "VPC + Bastion + Elastic Beanstalk + DB")
+
+</details>
+
+
 ### AWS Fargate
 
 [AWS Fargate](https://aws.amazon.com/fargate/) is part of [Amazon Elastic Container Service (ECS)](https://aws.amazon.com/ecs/). It's a managed service for running container-based applications, without having to worry about the underlying servers--sort of like [Lambda](https://aws.amazon.com/lambda/) for containers.
@@ -146,6 +167,19 @@ Creating a Fargate stack requires you to have first created a [VPC](#vpc) stack,
 - ELB target groups stuff
 - A [Fargate task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-task-definition.html)
 - A Fargate service with associated scaling resources
+
+</details>
+
+<details>
+	<summary>Diagrams</summary>
+
+
+With RDS/Aurora:
+![VPC + Bastion + Fargate + DB](images/vpc_bastion_fargate_db.png "VPC + Bastion + Fargate + DB")
+
+Without RDS/Aurora:
+
+![VPC + Bastion + Fargate](images/vpc_bastion_fargate.png "VPC + Bastion + Fargate")
 
 </details>
 
@@ -218,33 +252,33 @@ New services are not immediately available in all AWS Regions, please consult th
 <summary>Basic Infrastructure Templates (VPC etc)</summary>
 
 | CloudFormation | Region Name | Region | VPC | Bastion
-:---: | ------------ | ------------- | ------------- | ------------- 
+:---: | ------------ | ------------- | ------------- | -------------
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-1-vpc] | US East (N. Virginia) | us-east-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-1-vpc-bastion] | US East (N. Virginia) | us-east-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-1-vpc-bastion] | US East (N. Virginia) | us-east-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-2-vpc] | US East (Ohio) | us-east-2 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-2-vpc-bastion] | US East (Ohio) | us-east-2 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-2-vpc-bastion] | US East (Ohio) | us-east-2 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-west-1-vpc] | US West (N. California) | us-west-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-west-1-vpc-bastion] | US West (N. California) | us-west-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-west-1-vpc-bastion] | US West (N. California) | us-west-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ca-central-1-vpc] | Canada (Central) | ca-central-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ca-central-1-vpc-bastion] | Canada (Central) | ca-central-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ca-central-1-vpc-bastion] | Canada (Central) | ca-central-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][sa-east-1-vpc] | S. America (São Paulo) | sa-east-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][sa-east-1-vpc-bastion] | S. America (São Paulo) | sa-east-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][sa-east-1-vpc-bastion] | S. America (São Paulo) | sa-east-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-1-vpc] | EU (Ireland) | eu-west-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-1-vpc-bastion] | EU (Ireland) | eu-west-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-1-vpc-bastion] | EU (Ireland) | eu-west-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-2-vpc] | EU (London) | eu-west-2 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-2-vpc-bastion] | EU (London) | eu-west-2 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-2-vpc-bastion] | EU (London) | eu-west-2 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-3-vpc] | EU (Paris) | eu-west-3 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-3-vpc-bastion] | EU (Paris) | eu-west-3 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-3-vpc-bastion] | EU (Paris) | eu-west-3 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-central-1-vpc] | EU (Frankfurt) | eu-central-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-central-1-vpc-bastion] | EU (Frankfurt) | eu-central-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-central-1-vpc-bastion] | EU (Frankfurt) | eu-central-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-northeast-1-vpc] | Asia Pacific (Tokyo) | ap-northeast-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-northeast-1-vpc-bastion] | Asia Pacific (Tokyo) | ap-northeast-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-northeast-1-vpc-bastion] | Asia Pacific (Tokyo) | ap-northeast-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-northeast-2-vpc] | Asia Pacific (Seoul) | ap-northeast-2 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-northeast-2-vpc-bastion] | Asia Pacific (Seoul) | ap-northeast-2 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-northeast-2-vpc-bastion] | Asia Pacific (Seoul) | ap-northeast-2 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-south-1-vpc] | Asia Pacific (Mumbai) | ap-south-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-south-1-vpc-bastion] | Asia Pacific (Mumbai) | ap-south-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-south-1-vpc-bastion] | Asia Pacific (Mumbai) | ap-south-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-southeast-1-vpc] | Asia Pacific (Singapore) | ap-southeast-1 | ✅  |
-[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-southeast-1-vpc-bastion] | Asia Pacific (Singapore) | ap-southeast-1 | ✅  | ✅ 
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-southeast-1-vpc-bastion] | Asia Pacific (Singapore) | ap-southeast-1 | ✅  | ✅
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-southeast-2-vpc] | Asia Pacific (Sydney) | ap-southeast-2 | ✅  |
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-southeast-2-vpc-bastion] | Asia Pacific (Sydney) | ap-southeast-2 | ✅  | ✅
 
@@ -277,70 +311,82 @@ New services are not immediately available in all AWS Regions, please consult th
 <summary>AWS Fargate</summary>
 
 | CloudFormation | Region Name | Region | VPC | Bastion | DB | Fargate
-:---: | ------------ | ------------- | ------------- | ------------- | -------------  | ------------- 
+:---: | ------------ | ------------- | ------------- | ------------- | -------------  | -------------
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-1-vpc-bastion-fargate] | US East (N. Virginia) | us-east-1 | ✅  | ✅  || ✅  |
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-1-vpc-bastion-fargate-rds] | US East (N. Virginia) | us-east-1 | ✅  | ✅  | ✅  | ✅  |
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-2-vpc-bastion-fargate] | US East (Ohio) | us-east-2 | ✅  | ✅  || ✅  |
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-east-2-vpc-bastion-fargate-rds] | US East (Ohio) | us-east-2 | ✅  | ✅  | ✅  | ✅  |
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-west-2-vpc-bastion-fargate] | US West (Oregon) | us-west-2 | ✅  | ✅  || ✅  |
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][us-west-2-vpc-bastion-fargate-rds] | US West (Oregon) | us-west-2 | ✅  | ✅  | ✅  | ✅  |
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-1-vpc-bastion-fargate] | EU (Ireland) | eu-west-1 | ✅  | ✅  || ✅  |
+[<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][eu-west-1-vpc-bastion-fargate-rds] | EU (Ireland) | eu-west-1 | ✅  | ✅  | ✅  | ✅  |
 
 </details>
 
-[us-east-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[us-east-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[us-east-1-vpc-bastion-fargate]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-fargate.cfn.yml
-[us-east-1-vpc-bastion-fargate-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-fargate-rds.cfn.yml
-[us-east-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[us-east-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[us-east-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[us-east-1-vpc-bastion-fargate]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-fargate.cfn.yml
+[us-east-1-vpc-bastion-fargate-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-fargate-rds.cfn.yml
+[us-east-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[us-east-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[us-east-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[us-east-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[us-east-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[us-east-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[us-east-2-vpc-bastion-fargate]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-fargate.cfn.yml
+[us-east-2-vpc-bastion-fargate-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-fargate-rds.cfn.yml
+[us-east-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[us-west-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[us-west-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[us-west-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[us-west-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[us-west-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[us-west-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[us-west-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[us-west-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[us-west-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[us-west-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[us-west-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[us-west-2-vpc-bastion-fargate]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-fargate.cfn.yml
+[us-west-2-vpc-bastion-fargate-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-fargate-rds.cfn.yml
+[us-west-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[sa-east-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[sa-east-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[sa-east-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[sa-east-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[sa-east-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[sa-east-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[eu-west-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[eu-west-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[eu-west-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[eu-west-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[eu-west-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[eu-west-1-vpc-bastion-fargate]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-fargate.cfn.yml
+[eu-west-1-vpc-bastion-fargate-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-fargate-rds.cfn.yml
+[eu-west-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[eu-west-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[eu-west-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[eu-west-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[eu-west-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[eu-west-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[eu-west-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[eu-west-3-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[eu-west-3-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[eu-west-3-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[eu-west-3-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[eu-west-3-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[eu-west-3-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[eu-central-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[eu-central-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[eu-central-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[eu-central-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[eu-central-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[eu-central-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[ap-south-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[ap-south-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[ap-south-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[ap-south-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[ap-south-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[ap-south-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[ap-northeast-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[ap-northeast-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[ap-northeast-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[ap-northeast-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[ap-northeast-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[ap-northeast-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[ap-northeast-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[ap-northeast-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[ap-northeast-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[ap-northeast-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[ap-northeast-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[ap-northeast-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[ap-southeast-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[ap-southeast-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[ap-southeast-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[ap-southeast-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[ap-southeast-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[ap-southeast-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[ap-southeast-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[ap-southeast-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[ap-southeast-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[ap-southeast-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[ap-southeast-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[ap-southeast-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml
 
-[ca-central-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc.cfn.yml
-[ca-central-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion.cfn.yml
-[ca-central-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v3/vpc-bastion-eb-rds.cfn.yml
+[ca-central-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc.cfn.yml
+[ca-central-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion.cfn.yml
+[ca-central-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v4/vpc-bastion-eb-rds.cfn.yml

--- a/templates/elastic-beanstalk.cfn.yml
+++ b/templates/elastic-beanstalk.cfn.yml
@@ -130,15 +130,15 @@ Mappings:
   # Maps stack type parameter to solution stack name string
   StackMap:
     node:
-      stackName: 64bit Amazon Linux 2017.09 v4.4.6 running Node.js
+      stackName: 64bit Amazon Linux 2018.03 v4.5.0 running Node.js
     rails:
-      stackName: 64bit Amazon Linux 2017.09 v2.7.2 running Ruby 2.4 (Puma)
+      stackName: 64bit Amazon Linux 2018.03 v2.8.0 running Ruby 2.4 (Puma)
     spring:
-      stackName: 64bit Amazon Linux 2017.09 v2.7.7 running Tomcat 8 Java 8
+      stackName: 64bit Amazon Linux 2018.03 v3.0.0 running Tomcat 8 Java 8
     python:
-      stackName: 64bit Amazon Linux 2017.09 v2.6.6 running Python 2.7
+      stackName: 64bit Amazon Linux 2018.03 v2.7.0 running Python 2.7
     python3:
-      stackName: 64bit Amazon Linux 2017.09 v2.6.6 running Python 3.6
+      stackName: 64bit Amazon Linux 2018.03 v2.7.0 running Python 3.6
 
 Resources:
 

--- a/templates/fargate-service.cfn.yml
+++ b/templates/fargate-service.cfn.yml
@@ -79,23 +79,23 @@ Parameters:
     MaxLength: 255
     ConstraintDescription: Value must be between 1 and 255 characters
 
-  GitHubSourceRepo:
+  GitSourceRepo:
     Type: String
-    Description: GitHub source repository - must contain a Dockerfile in the base
+    Description: CodeCommit or GitHub source repository - must contain a Dockerfile in the base
 
-  GitHubBranch:
+  GitBranch:
     Type: String
     Default: master
-    Description: GitHub repository branch to trigger builds
+    Description: CodeCommit or GitHub git repository branch - change triggers a new build
 
   GitHubToken:
     Type: String
     NoEcho: true
-    Description: "GitHub API token - see: https://github.com/blog/1509-personal-api-tokens"
+    Description: "GitHub API token - leave blank if using CodeCommit - see: https://github.com/blog/1509-personal-api-tokens"
 
   GitHubUser:
     Type: String
-    Description: GitHub username
+    Description: GitHub username or organization - leave blank if using CodeCommit
 
   CodeBuildDockerImage:
     Type: String
@@ -104,7 +104,7 @@ Parameters:
   SeedDockerImage:
     Type: String
     Default: registry.hub.docker.com/library/nginx:1.13
-    Description: The initial image, before the GitHub repo above is deployed. Existing application images in ECR should override this parameter
+    Description: Initial image before CodePipeline is executed. Existing application images in ECR should override this parameter
 
   ContainerCpu:
     Type: Number
@@ -168,6 +168,12 @@ Parameters:
 Conditions:
 
   IsDbStackSet: !Not [ !Equals [ !Ref DatabaseStackName, "" ] ]
+
+  IsGitHub: !And
+    - !Not [ !Equals [ !Ref GitHubToken, "" ] ]
+    - !Not [ !Equals [ !Ref GitHubUser, "" ] ]
+
+  IsCodeCommit: !Not [ Condition: IsGitHub ]
 
   AddServiceToAlb: !Equals [ !Ref RegisterServiceWithAlb, true ]
 
@@ -256,7 +262,7 @@ Resources:
                   - printf '[{"name":"${ServiceName}","imageUri":"%s"}]' $REPOSITORY_URI:$TAG > build.json
             artifacts:
               files: build.json
-          - ServiceName: !Ref GitHubSourceRepo
+          - ServiceName: !Ref GitSourceRepo
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Type: LINUX_CONTAINER
@@ -268,9 +274,9 @@ Resources:
           - Name: ENVIRONMENT_NAME
             Value: !Ref EnvironmentName
           - Name: REPOSITORY_NAME
-            Value: !Ref GitHubSourceRepo
+            Value: !Ref GitSourceRepo
           - Name: REPOSITORY_BRANCH
-            Value: !Ref GitHubBranch
+            Value: !Ref GitBranch
       Name: !Ref AWS::StackName
       ServiceRole: !Ref CodeBuildServiceRole
 
@@ -299,6 +305,11 @@ Resources:
                   - ecs:UpdateService
                   - codebuild:StartBuild
                   - codebuild:BatchGetBuilds
+                  - codecommit:GetBranch
+                  - codecommit:GetCommit
+                  - codecommit:UploadArchive
+                  - codecommit:GetUploadArchiveStatus
+                  - codecommit:CancelUploadArchive
                   - iam:PassRole
               - Resource: !Sub arn:aws:s3:::${CodePipelineArtifactBucket}/*
                 Effect: Allow
@@ -310,11 +321,72 @@ Resources:
     DependsOn:
       - CodePipelineArtifactBucket
 
+  # This CodePipeline is used for CodeCommit repos. It triggers on a commit to the Git branch passed,
+  # builds the Docker image and then deploys the container in the Fargate Cluster. CodePipeline can support N stages.
+  # For example, you may want to add a stage to test your build and/or container.
+  CodePipelineCodeCommit:
+    Type: AWS::CodePipeline::Pipeline
+    Condition: IsCodeCommit
+    Properties:
+      RoleArn: !GetAtt CodePipelineServiceRole.Arn
+      ArtifactStore:
+        Type: S3
+        Location: !Ref CodePipelineArtifactBucket
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: App
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: 1
+                Provider: CodeCommit
+              Configuration:
+                RepositoryName: !Ref GitSourceRepo
+                BranchName: !Ref GitBranch
+              OutputArtifacts:
+                - Name: App
+              RunOrder: 1
+        - Name: Build
+          Actions:
+            - Name: Build
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref CodeBuildProject
+              InputArtifacts:
+                - Name: App
+              OutputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 1
+        - Name: Deploy
+          Actions:
+            - Name: Deploy
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: ECS
+              Configuration:
+                ClusterName:
+                  Fn::ImportValue: !Sub ${FargateStackName}-FargateEcsClusterName
+                ServiceName: !If [ AddServiceToAlb, !GetAtt ServiceWithAlb.Name, !GetAtt ServiceWithoutAlb.Name ]
+                FileName: build.json
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 1
+    DependsOn:
+      - CodePipelineArtifactBucket
+
   # This CodePipeline triggers on a commit to the Git branch passed, builds the Docker image
   # and then deploys the container in the Fargate Cluster. CodePipeline can support N stages. For
   # example, you may want to add a stage to test your build and/or container.
-  CodePipeline:
+  CodePipelineGitHub:
     Type: AWS::CodePipeline::Pipeline
+    Condition: IsGitHub
     Properties:
       RoleArn: !GetAtt CodePipelineServiceRole.Arn
       ArtifactStore:
@@ -331,8 +403,8 @@ Resources:
                 Provider: GitHub
               Configuration:
                 Owner: !Ref GitHubUser
-                Repo: !Ref GitHubSourceRepo
-                Branch: !Ref GitHubBranch
+                Repo: !Ref GitSourceRepo
+                Branch: !Ref GitBranch
                 OAuthToken: !Ref GitHubToken
               OutputArtifacts:
                 - Name: App
@@ -377,7 +449,7 @@ Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /fargate/app/${EnvironmentName}/${GitHubSourceRepo}/${GitHubBranch}
+      LogGroupName: !Sub /fargate/${AWS::StackName}/${GitSourceRepo}/${GitBranch}/${EnvironmentName}
       RetentionInDays: !Ref ContainerLogRetentionInDays
 
   TaskRole:
@@ -418,7 +490,7 @@ Resources:
       TaskRoleArn: !GetAtt TaskRole.Arn
       ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
       ContainerDefinitions:
-        - Name: !Ref GitHubSourceRepo
+        - Name: !Ref GitSourceRepo
           Image: !Ref SeedDockerImage
           Essential: true
           PortMappings:
@@ -443,7 +515,7 @@ Resources:
             Options:
               awslogs-region: !Ref AWS::Region
               awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: !Ref GitHubSourceRepo
+              awslogs-stream-prefix: !Ref GitSourceRepo
     DependsOn:
       - LogGroup
       - TaskExecutionRole
@@ -478,7 +550,7 @@ Resources:
       LaunchType: FARGATE
       TaskDefinition: !Ref TaskDefinition
       LoadBalancers:
-        - ContainerName: !Ref GitHubSourceRepo
+        - ContainerName: !Ref GitSourceRepo
           ContainerPort:
             Fn::ImportValue: !Sub ${NetworkStackName}-AppIngressPort
           TargetGroupArn: !Ref TargetGroup
@@ -631,9 +703,9 @@ Resources:
       TargetType: ip
       Tags:
       - Key: Repository
-        Value: !Ref GitHubSourceRepo
+        Value: !Ref GitSourceRepo
       - Key: Branch
-        Value: !Ref GitHubBranch
+        Value: !Ref GitBranch
       - Key: Stack
         Value: !Ref AWS::StackName
       - Key: Environment

--- a/templates/fargate.cfn.yml
+++ b/templates/fargate.cfn.yml
@@ -75,14 +75,14 @@ Parameters:
     MaxLength: 255
     ConstraintDescription: Value must be between 1 and 255 characters
 
-  GitHubSourceRepo:
+  GitSourceRepo:
     Type: String
-    Description: GitHub source repository - must contain a Dockerfile in the base
+    Description: CodeCommit or GitHub source repository - must contain a Dockerfile in the base
 
-  GitHubBranch:
+  GitBranch:
     Type: String
     Default: master
-    Description: GitHub repository branch to trigger builds
+    Description: CodeCommit or GitHub git repository branch - change triggers a new build
 
   GitHubToken:
     Type: String
@@ -91,7 +91,7 @@ Parameters:
 
   GitHubUser:
     Type: String
-    Description: GitHub username
+    Description: GitHub username or organization - leave blank if using CodeCommit
 
   CodeBuildDockerImage:
     Type: String
@@ -100,7 +100,7 @@ Parameters:
   SeedDockerImage:
     Type: String
     Default: registry.hub.docker.com/library/nginx:1.13
-    Description: The initial image, before the GitHub repo above is deployed. Existing application images in ECR should override this parameter
+    Description: Initial image before CodePipeline is executed. Existing application images in ECR should override this parameter
 
   DefaultContainerCpu:
     Type: Number
@@ -216,15 +216,21 @@ Parameters:
 
 Conditions:
 
-   IsTlsEnabled: !Not [ !Equals [ !Ref SSLCertificateArn, "" ] ]
+  IsTlsEnabled: !Not [ !Equals [ !Ref SSLCertificateArn, "" ] ]
 
-   IsDbStackSet: !Not [ !Equals [ !Ref DatabaseStackName, "" ] ]
+  IsDbStackSet: !Not [ !Equals [ !Ref DatabaseStackName, "" ] ]
 
-   CreateRoute53Record: !And
-     - !Not [ !Equals [ !Ref LoadBalancerDomainName, "" ] ]
-     - !Not [ !Equals [ !Ref HostedZoneName, "" ] ]
+  CreateRoute53Record: !And
+    - !Not [ !Equals [ !Ref LoadBalancerDomainName, "" ] ]
+    - !Not [ !Equals [ !Ref HostedZoneName, "" ] ]
 
-   IsLBAlarmEnabled: !Equals [ !Ref EnableLBAlarm, true ]
+  IsGitHub: !And
+    - !Not [ !Equals [ !Ref GitHubToken, "" ] ]
+    - !Not [ !Equals [ !Ref GitHubUser, "" ] ]
+
+  IsCodeCommit: !Not [ Condition: IsGitHub ]
+
+  IsLBAlarmEnabled: !Equals [ !Ref EnableLBAlarm, true ]
 
 
 Resources:
@@ -310,7 +316,7 @@ Resources:
                   - printf '[{"name":"${ServiceName}","imageUri":"%s"}]' $REPOSITORY_URI:$TAG > build.json
             artifacts:
               files: build.json
-          - ServiceName: !Ref GitHubSourceRepo
+          - ServiceName: !Ref GitSourceRepo
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Type: LINUX_CONTAINER
@@ -321,9 +327,9 @@ Resources:
           - Name: ENVIRONMENT_NAME
             Value: !Ref EnvironmentName
           - Name: REPOSITORY_NAME
-            Value: !Ref GitHubSourceRepo
+            Value: !Ref GitSourceRepo
           - Name: REPOSITORY_BRANCH
-            Value: !Ref GitHubBranch
+            Value: !Ref GitBranch
       Name: !Ref AWS::StackName
       ServiceRole: !Ref CodeBuildServiceRole
 
@@ -352,6 +358,11 @@ Resources:
                   - ecs:UpdateService
                   - codebuild:StartBuild
                   - codebuild:BatchGetBuilds
+                  - codecommit:GetBranch
+                  - codecommit:GetCommit
+                  - codecommit:UploadArchive
+                  - codecommit:GetUploadArchiveStatus
+                  - codecommit:CancelUploadArchive
                   - iam:PassRole
               - Resource: !Sub arn:aws:s3:::${CodePipelineArtifactBucket}/*
                 Effect: Allow
@@ -364,11 +375,74 @@ Resources:
       - CodePipelineArtifactBucket
       - FargateEcsCluster
 
-  # This CodePipeline triggers on a commit to the Git branch passed, builds the Docker image
-  # and then deploys the container in the Fargate Cluster. CodePipeline can support N stages. For
-  # example, you may want to add a stage to test your build and/or container.
-  CodePipeline:
+  # This CodePipeline is used for CodeCommit repos. It triggers on a commit to the Git branch passed,
+  # builds the Docker image and then deploys the container in the Fargate Cluster. CodePipeline can support N stages.
+  # For example, you may want to add a stage to test your build and/or container.
+  CodePipelineCodeCommit:
     Type: AWS::CodePipeline::Pipeline
+    Condition: IsCodeCommit
+    Properties:
+      RoleArn: !GetAtt CodePipelineServiceRole.Arn
+      ArtifactStore:
+        Type: S3
+        Location: !Ref CodePipelineArtifactBucket
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: App
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: 1
+                Provider: CodeCommit
+              Configuration:
+                RepositoryName: !Ref GitSourceRepo
+                BranchName: !Ref GitBranch
+              OutputArtifacts:
+                - Name: App
+              RunOrder: 1
+        - Name: Build
+          Actions:
+            - Name: Build
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref CodeBuildProject
+              InputArtifacts:
+                - Name: App
+              OutputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 1
+        - Name: Deploy
+          Actions:
+            - Name: Deploy
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: ECS
+              Configuration:
+                ClusterName: !Ref FargateEcsCluster
+                ServiceName: !GetAtt DefaultFargateService.Name
+                FileName: build.json
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 1
+    DependsOn:
+      - CodePipelineArtifactBucket
+      - CodeBuildProject
+      - CodePipelineServiceRole
+      - DefaultFargateService
+
+  # This CodePipeline is used for GitHub based repos. It triggers on a commit to the Git branch passed,
+  # builds the Docker image and then deploys the container in the Fargate Cluster. CodePipeline can support N stages.
+  # For example, you may want to add a stage to test your build and/or container.
+  CodePipelineGitHub:
+    Type: AWS::CodePipeline::Pipeline
+    Condition: IsGitHub
     Properties:
       RoleArn: !GetAtt CodePipelineServiceRole.Arn
       ArtifactStore:
@@ -385,8 +459,8 @@ Resources:
                 Provider: GitHub
               Configuration:
                 Owner: !Ref GitHubUser
-                Repo: !Ref GitHubSourceRepo
-                Branch: !Ref GitHubBranch
+                Repo: !Ref GitSourceRepo
+                Branch: !Ref GitBranch
                 OAuthToken: !Ref GitHubToken
               OutputArtifacts:
                 - Name: App
@@ -522,9 +596,9 @@ Resources:
       TargetType: ip
       Tags:
       - Key: Repository
-        Value: !Ref GitHubSourceRepo
+        Value: !Ref GitSourceRepo
       - Key: Branch
-        Value: !Ref GitHubBranch
+        Value: !Ref GitBranch
       - Key: Stack
         Value: !Ref AWS::StackName
       - Key: Environment
@@ -535,7 +609,7 @@ Resources:
   DefaultLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /fargate/app/${EnvironmentName}/${GitHubSourceRepo}/${GitHubBranch}
+      LogGroupName: !Sub /fargate/${AWS::StackName}/${GitSourceRepo}/${GitBranch}/${EnvironmentName}
       RetentionInDays: !Ref ContainerLogRetentionInDays
 
   DefaultTaskRole:
@@ -585,7 +659,7 @@ Resources:
       TaskRoleArn: !GetAtt DefaultTaskRole.Arn
       ExecutionRoleArn: !GetAtt DefaultTaskExecutionRole.Arn
       ContainerDefinitions:
-        - Name: !Ref GitHubSourceRepo
+        - Name: !Ref GitSourceRepo
           Image: !Ref SeedDockerImage
           Essential: true
           PortMappings:
@@ -611,7 +685,7 @@ Resources:
             Options:
               awslogs-region: !Ref AWS::Region
               awslogs-group: !Ref DefaultLogGroup
-              awslogs-stream-prefix: !Ref GitHubSourceRepo
+              awslogs-stream-prefix: !Ref GitSourceRepo
     DependsOn:
       - DefaultContainerBucket
       - DefaultLogGroup
@@ -626,7 +700,7 @@ Resources:
       LaunchType: FARGATE
       TaskDefinition: !Ref DefaultFargateTaskDefinition
       LoadBalancers:
-        - ContainerName: !Ref GitHubSourceRepo
+        - ContainerName: !Ref GitSourceRepo
           ContainerPort:
             Fn::ImportValue: !Sub ${NetworkStackName}-AppIngressPort
           TargetGroupArn: !Ref DefaultTargetGroup

--- a/vpc-bastion-eb-rds.cfn.yml
+++ b/vpc-bastion-eb-rds.cfn.yml
@@ -9,7 +9,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v3
+    Default: awslabs-startup-kit-templates-deploy-v4
     Description: The template bucket for the CloudFormation templates
 
   EnvironmentName:

--- a/vpc-bastion-fargate-rds.cfn.yml
+++ b/vpc-bastion-fargate-rds.cfn.yml
@@ -9,7 +9,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v3
+    Default: awslabs-startup-kit-templates-deploy-v4
     Description: The template bucket for the CloudFormation templates
 
   # vpc.cfn.yml parameters
@@ -135,23 +135,23 @@ Parameters:
     MaxLength: 255
     ConstraintDescription: Value must be between 1 and 255 characters
 
-  GitHubSourceRepo:
+  GitSourceRepo:
     Type: String
-    Description: GitHub source repository - must contain a Dockerfile in the base
+    Description: CodeCommit or GitHub source repository - must contain a Dockerfile in the base
 
-  GitHubBranch:
+  GitBranch:
     Type: String
     Default: master
-    Description: GitHub repository branch to trigger builds
+    Description: CodeCommit or GitHub git repository branch - change triggers a new build
 
   GitHubToken:
     Type: String
     NoEcho: true
-    Description: "GitHub API token - see: https://github.com/blog/1509-personal-api-tokens"
+    Description: "GitHub API token - leave blank if using CodeCommit - see: https://github.com/blog/1509-personal-api-tokens"
 
   GitHubUser:
     Type: String
-    Description: GitHub username
+    Description: GitHub username or organization - leave blank if using CodeCommit
 
   CodeBuildDockerImage:
     Type: String
@@ -160,7 +160,7 @@ Parameters:
   SeedDockerImage:
     Type: String
     Default: registry.hub.docker.com/library/nginx:1.13
-    Description: The initial image, before the GitHub repo above is deployed. Existing application images in ECR should override this parameter
+    Description: Initial image before CodePipeline is executed. Existing application images in ECR should override this parameter
 
   DefaultContainerCpu:
     Type: Number
@@ -469,10 +469,10 @@ Metadata:
         Parameters:
           - CodeBuildDockerImage
           - SeedDockerImage
+          - GitSourceRepo
+          - GitBranch
           - GitHubUser
           - GitHubToken
-          - GitHubSourceRepo
-          - GitHubBranch
       - Label:
           default: Elastic Container Registry
         Parameters:
@@ -505,10 +505,10 @@ Metadata:
         default: Tagged Images Max
       DaysToRetainUntaggedContainerImages:
         default: Untagged Images
-      GitHubSourceRepo:
-        default: GitHub Repo
-      GitHubBranch:
-        default: GitHub Branch
+      GitSourceRepo:
+        default: Git Repo
+      GitBranch:
+        default: Git Branch
       GitHubUser:
         default: GitHub User
       GitHubToken:
@@ -676,8 +676,8 @@ Resources:
         AppProtocol: !Ref AppProtocol
         SSLCertificateArn: !Ref SSLCertificateArn
         HealthCheckPath: !Ref HealthCheckPath
-        GitHubSourceRepo: !Ref GitHubSourceRepo
-        GitHubBranch: !Ref GitHubBranch
+        GitSourceRepo: !Ref GitSourceRepo
+        GitBranch: !Ref GitBranch
         GitHubToken: !Ref GitHubToken
         GitHubUser: !Ref GitHubUser
         CodeBuildDockerImage: !Ref CodeBuildDockerImage

--- a/vpc-bastion-fargate.cfn.yml
+++ b/vpc-bastion-fargate.cfn.yml
@@ -9,7 +9,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v3
+    Default: awslabs-startup-kit-templates-deploy-v4
     Description: The template bucket for the CloudFormation templates
 
   # vpc.cfn.yml parameters
@@ -105,23 +105,23 @@ Parameters:
     MaxLength: 255
     ConstraintDescription: Value must be between 1 and 255 characters
 
-  GitHubSourceRepo:
+  GitSourceRepo:
     Type: String
-    Description: GitHub source repository - must contain a Dockerfile in the base
+    Description: CodeCommit or GitHub source repository - must contain a Dockerfile in the base
 
-  GitHubBranch:
+  GitBranch:
     Type: String
     Default: master
-    Description: GitHub repository branch to trigger builds
+    Description: CodeCommit or GitHub git repository branch - change triggers a new build
 
   GitHubToken:
     Type: String
     NoEcho: true
-    Description: "GitHub API token - see: https://github.com/blog/1509-personal-api-tokens"
+    Description: "GitHub API token - leave blank if using CodeCommit - see: https://github.com/blog/1509-personal-api-tokens"
 
   GitHubUser:
     Type: String
-    Description: GitHub username
+    Description: GitHub username or organization - leave blank if using CodeCommit
 
   CodeBuildDockerImage:
     Type: String
@@ -130,7 +130,7 @@ Parameters:
   SeedDockerImage:
     Type: String
     Default: registry.hub.docker.com/library/nginx:1.13
-    Description: The initial image, before the GitHub repo above is deployed. Existing application images in ECR should override this parameter
+    Description: Initial image before CodePipeline is executed. Existing application images in ECR should override this parameter
 
   DefaultContainerCpu:
     Type: Number
@@ -297,10 +297,10 @@ Metadata:
         Parameters:
           - CodeBuildDockerImage
           - SeedDockerImage
+          - GitSourceRepo
+          - GitBranch
           - GitHubUser
           - GitHubToken
-          - GitHubSourceRepo
-          - GitHubBranch
       - Label:
           default: Elastic Container Registry
         Parameters:
@@ -333,10 +333,10 @@ Metadata:
         default: Tagged Images Max
       DaysToRetainUntaggedContainerImages:
         default: Untagged Images
-      GitHubSourceRepo:
-        default: GitHub Repo
-      GitHubBranch:
-        default: GitHub Branch
+      GitSourceRepo:
+        default: Git Repo
+      GitBranch:
+        default: Git Branch
       GitHubUser:
         default: GitHub User
       GitHubToken:
@@ -421,8 +421,8 @@ Resources:
         AppProtocol: !Ref AppProtocol
         SSLCertificateArn: !Ref SSLCertificateArn
         HealthCheckPath: !Ref HealthCheckPath
-        GitHubSourceRepo: !Ref GitHubSourceRepo
-        GitHubBranch: !Ref GitHubBranch
+        GitSourceRepo: !Ref GitSourceRepo
+        GitBranch: !Ref GitBranch
         GitHubToken: !Ref GitHubToken
         GitHubUser: !Ref GitHubUser
         CodeBuildDockerImage: !Ref CodeBuildDockerImage

--- a/vpc-bastion.cfn.yml
+++ b/vpc-bastion.cfn.yml
@@ -9,7 +9,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v3
+    Default: awslabs-startup-kit-templates-deploy-v4
     Description: The template bucket for the CloudFormation templates
 
   AvailabilityZone1:

--- a/vpc.cfn.yml
+++ b/vpc.cfn.yml
@@ -8,7 +8,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v3
+    Default: awslabs-startup-kit-templates-deploy-v4
     Description: The template bucket for the CloudFormation templates
 
   AvailabilityZone1:


### PR DESCRIPTION
This PR primarily adds support for CodeCommit in the Fargate templates. The PR also adds support for the additional AWS regions that now support Fargate (us-east-2, us-west-2, eu-west-1). The Elastic Beanstalk stacks were also updated.  Lastly, this PR adds the design diagrams Roshan created in his last PR to the README.md file. Roshan is working on updating the Fargate images to indicate that CodeCommit is also supported.

This PR was tested by creating both CodeCommit and GitHub configured stacks in each of the supported regions. The template that adds additional services to the Fargate cluster was also tested.